### PR TITLE
Test PR: Change scan target to terraform-aws-eks

### DIFF
--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -19,12 +19,13 @@ jobs:
       contents: read
       security-events: write
       actions: read
+      pull-requests: write
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Run Trivy IaC scan
+    - name: Run Trivy IaC scan (SARIF format)
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
@@ -34,14 +35,7 @@ jobs:
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
         exit-code: '0'
 
-    - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v3
-      if: always()
-      with:
-        sarif_file: 'trivy-iac-results.sarif'
-        category: 'trivy-iac-scan'
-
-    - name: Run Trivy IaC scan (table format)
+    - name: Run Trivy IaC scan (table format for PR comment)
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
@@ -49,12 +43,102 @@ jobs:
         format: 'table'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
         output: 'trivy-iac-results.txt'
+        exit-code: '0'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v3
+      if: always()
+      with:
+        sarif_file: 'trivy-iac-results.sarif'
+        category: 'trivy-iac-scan'
+
+    - name: Parse scan results for PR comment
+      if: github.event_name == 'pull_request'
+      run: |
+        echo "TRIVY_RESULTS<<EOF" >> $GITHUB_ENV
+        if [ -f trivy-iac-results.txt ] && [ -s trivy-iac-results.txt ]; then
+          # Count issues by severity
+          CRITICAL=$(grep -c "CRITICAL" trivy-iac-results.txt || echo "0")
+          HIGH=$(grep -c "HIGH" trivy-iac-results.txt || echo "0")
+          MEDIUM=$(grep -c "MEDIUM" trivy-iac-results.txt || echo "0")
+          LOW=$(grep -c "LOW" trivy-iac-results.txt || echo "0")
+          
+          echo "## 🔒 Trivy IaC Security Scan Results"
+          echo ""
+          echo "**Scan Target:** \`example_app/terraform-aws-eks\`"
+          echo ""
+          echo "### 📊 Issue Summary"
+          echo "| Severity | Count |"
+          echo "|----------|-------|"
+          echo "| 🔴 Critical | $CRITICAL |"
+          echo "| 🟠 High | $HIGH |"
+          echo "| 🟡 Medium | $MEDIUM |"
+          echo "| 🔵 Low | $LOW |"
+          echo ""
+          
+          if [ $CRITICAL -gt 0 ] || [ $HIGH -gt 0 ]; then
+            echo "⚠️ **Action Required:** Critical or High severity issues found!"
+            echo ""
+          fi
+          
+          echo "### 📋 Detailed Results"
+          echo "\`\`\`"
+          cat trivy-iac-results.txt
+          echo "\`\`\`"
+          echo ""
+          echo "---"
+          echo "📋 **Full results available in [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)**"
+        else
+          echo "## ✅ Trivy IaC Security Scan Results"
+          echo ""
+          echo "**Scan Target:** \`example_app/terraform-aws-eks\`"
+          echo ""
+          echo "🎉 **No security issues found!** Your infrastructure configuration looks secure."
+          echo ""
+          echo "---"
+          echo "📋 **Scan details available in [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)**"
+        fi
+        EOF
+
+    - name: Comment PR with scan results
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { owner, repo } = context.repo;
+          const issue_number = context.issue.number;
+          
+          // Delete previous Trivy comments to avoid spam
+          const comments = await github.rest.issues.listComments({
+            owner,
+            repo,
+            issue_number,
+          });
+          
+          for (const comment of comments.data) {
+            if (comment.body.includes('🔒 Trivy IaC Security Scan Results') || 
+                comment.body.includes('✅ Trivy IaC Security Scan Results')) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: comment.id,
+              });
+            }
+          }
+          
+          // Post new comment
+          await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number,
+            body: process.env.TRIVY_RESULTS
+          });
 
     - name: Display scan results
       if: always()
       run: |
         echo "=== Trivy IaC Scan Results ==="
-        if [ -f trivy-iac-results.txt ]; then
+        if [ -f trivy-iac-results.txt ] && [ -s trivy-iac-results.txt ]; then
           cat trivy-iac-results.txt
         else
           echo "No IaC security issues found!"

--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -55,58 +55,110 @@ jobs:
     - name: Parse scan results for PR comment
       if: github.event_name == 'pull_request'
       run: |
-        echo "TRIVY_RESULTS<<EOF" >> $GITHUB_ENV
         if [ -f trivy-iac-results.txt ] && [ -s trivy-iac-results.txt ]; then
-          # Count issues by severity
-          CRITICAL=$(grep -c "CRITICAL" trivy-iac-results.txt || echo "0")
-          HIGH=$(grep -c "HIGH" trivy-iac-results.txt || echo "0")
-          MEDIUM=$(grep -c "MEDIUM" trivy-iac-results.txt || echo "0")
-          LOW=$(grep -c "LOW" trivy-iac-results.txt || echo "0")
+          # Count issues by severity (handle case where grep finds nothing)
+          CRITICAL=$(grep -c "CRITICAL" trivy-iac-results.txt || true)
+          HIGH=$(grep -c "HIGH" trivy-iac-results.txt || true)
+          MEDIUM=$(grep -c "MEDIUM" trivy-iac-results.txt || true)
+          LOW=$(grep -c "LOW" trivy-iac-results.txt || true)
           
-          echo "## 🔒 Trivy IaC Security Scan Results"
-          echo ""
-          echo "**Scan Target:** \`example_app/terraform-aws-eks\`"
-          echo ""
-          echo "### 📊 Issue Summary"
-          echo "| Severity | Count |"
-          echo "|----------|-------|"
-          echo "| 🔴 Critical | $CRITICAL |"
-          echo "| 🟠 High | $HIGH |"
-          echo "| 🟡 Medium | $MEDIUM |"
-          echo "| 🔵 Low | $LOW |"
-          echo ""
+          # Ensure counts are numeric
+          CRITICAL=${CRITICAL:-0}
+          HIGH=${HIGH:-0}
+          MEDIUM=${MEDIUM:-0}
+          LOW=${LOW:-0}
           
-          if [ $CRITICAL -gt 0 ] || [ $HIGH -gt 0 ]; then
-            echo "⚠️ **Action Required:** Critical or High severity issues found!"
-            echo ""
+          # Create the PR comment content in a file to avoid environment variable issues
+          cat > pr_comment.md << 'COMMENT_EOF'
+        ## 🔒 Trivy IaC Security Scan Results
+
+        **Scan Target:** `example_app/terraform-aws-eks`
+
+        ### 📊 Issue Summary
+        | Severity | Count |
+        |----------|-------|
+        | 🔴 Critical | CRITICAL_COUNT |
+        | 🟠 High | HIGH_COUNT |
+        | 🟡 Medium | MEDIUM_COUNT |
+        | 🔵 Low | LOW_COUNT |
+
+        CRITICAL_WARNING
+
+        ### 📋 Detailed Results
+        <details>
+        <summary>Click to expand detailed scan results</summary>
+
+        ```
+        SCAN_RESULTS_PLACEHOLDER
+        ```
+        </details>
+
+        ---
+        � **Full results available in [Security tab](SECURITY_TAB_URL)**
+        COMMENT_EOF
+          
+          # Replace placeholders with actual values
+          sed -i "s/CRITICAL_COUNT/$CRITICAL/g" pr_comment.md
+          sed -i "s/HIGH_COUNT/$HIGH/g" pr_comment.md
+          sed -i "s/MEDIUM_COUNT/$MEDIUM/g" pr_comment.md
+          sed -i "s/LOW_COUNT/$LOW/g" pr_comment.md
+          sed -i "s|SECURITY_TAB_URL|${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning|g" pr_comment.md
+          
+          # Add warning if critical or high issues found
+          if [ "$CRITICAL" -gt 0 ] || [ "$HIGH" -gt 0 ]; then
+            sed -i "s/CRITICAL_WARNING/⚠️ **Action Required:** Critical or High severity issues found!/" pr_comment.md
+          else
+            sed -i "s/CRITICAL_WARNING//" pr_comment.md
           fi
           
-          echo "### 📋 Detailed Results"
-          echo "\`\`\`"
-          cat trivy-iac-results.txt
-          echo "\`\`\`"
-          echo ""
-          echo "---"
-          echo "📋 **Full results available in [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)**"
+          # Replace scan results (limit to first 100 lines to avoid size issues)
+          head -100 trivy-iac-results.txt > scan_results_snippet.txt
+          python3 << 'PYTHON_EOF'
+        import re
+        
+        # Read the files
+        with open('pr_comment.md', 'r') as f:
+            content = f.read()
+        
+        with open('scan_results_snippet.txt', 'r') as f:
+            scan_results = f.read()
+        
+        # Replace the placeholder
+        content = content.replace('SCAN_RESULTS_PLACEHOLDER', scan_results)
+        
+        # Write back
+        with open('pr_comment.md', 'w') as f:
+            f.write(content)
+        PYTHON_EOF
+          
         else
-          echo "## ✅ Trivy IaC Security Scan Results"
-          echo ""
-          echo "**Scan Target:** \`example_app/terraform-aws-eks\`"
-          echo ""
-          echo "🎉 **No security issues found!** Your infrastructure configuration looks secure."
-          echo ""
-          echo "---"
-          echo "📋 **Scan details available in [Security tab](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning)**"
+          # No issues found - create simple success message
+          cat > pr_comment.md << 'SUCCESS_EOF'
+        ## ✅ Trivy IaC Security Scan Results
+
+        **Scan Target:** `example_app/terraform-aws-eks`
+
+        🎉 **No security issues found!** Your infrastructure configuration looks secure.
+
+        ---
+        📋 **Scan details available in [Security tab](SECURITY_TAB_URL)**
+        SUCCESS_EOF
+          
+          # Replace security tab URL
+          sed -i "s|SECURITY_TAB_URL|${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning|g" pr_comment.md
         fi
-        EOF
 
     - name: Comment PR with scan results
       if: github.event_name == 'pull_request'
       uses: actions/github-script@v7
       with:
         script: |
+          const fs = require('fs');
           const { owner, repo } = context.repo;
           const issue_number = context.issue.number;
+          
+          // Read the comment content from file
+          const commentBody = fs.readFileSync('pr_comment.md', 'utf8');
           
           // Delete previous Trivy comments to avoid spam
           const comments = await github.rest.issues.listComments({
@@ -131,7 +183,7 @@ jobs:
             owner,
             repo,
             issue_number,
-            body: process.env.TRIVY_RESULTS
+            body: commentBody
           });
 
     - name: Display scan results

--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -1,5 +1,8 @@
 name: Trivy IaC Security Scan
 
+# This workflow scans Terraform configurations for security issues
+# and uploads results to GitHub Security tab
+
 on:
   push:
     branches: [ "main", "develop" ]

--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -25,7 +25,7 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
-        scan-ref: 'example_app/learn-terraform-provision-eks-cluster'
+        scan-ref: 'example_app/terraform-aws-eks'
         format: 'sarif'
         output: 'trivy-iac-results.sarif'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
@@ -42,7 +42,7 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
-        scan-ref: 'example_app/learn-terraform-provision-eks-cluster'
+        scan-ref: 'example_app/terraform-aws-eks'
         format: 'table'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
         output: 'trivy-iac-results.txt'
@@ -56,83 +56,6 @@ jobs:
         else
           echo "No IaC security issues found!"
         fi
-
-    - name: Close alerts for fixed issues
-      uses: actions/github-script@v7
-      continue-on-error: true
-      if: always()
-      with:
-        script: |
-          try {
-            const fs = require('fs');
-            
-            // Wait for SARIF upload to process
-            await new Promise(resolve => setTimeout(resolve, 10000));
-            
-            // Read current scan results to see what issues were found
-            let scanHasAnyIssues = false;
-            if (fs.existsSync('trivy-iac-results.txt')) {
-              const scanContent = fs.readFileSync('trivy-iac-results.txt', 'utf8');
-              console.log('Scan file found, checking for issues...');
-              
-              // Check if scan has any security issues
-              scanHasAnyIssues = scanContent.includes('CRITICAL') || 
-                                scanContent.includes('HIGH') || 
-                                scanContent.includes('MEDIUM') ||
-                                scanContent.includes('LOW');
-              
-              console.log(`Current scan has issues: ${scanHasAnyIssues}`);
-            } else {
-              console.log('❌ Scan results file not found, assuming no issues');
-            }
-            
-            // Get all current open alerts
-            const openAlerts = await github.rest.codeScanning.listAlertsForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open'
-            });
-            
-            console.log(`Found ${openAlerts.data.length} open alerts to evaluate`);
-            
-            let closedCount = 0;
-            let keptOpenCount = 0;
-            
-            for (const alert of openAlerts.data) {
-              const ruleId = alert.rule?.id;
-              const alertDescription = alert.rule?.description || alert.most_recent_instance?.message?.text || '';
-              
-              console.log(`Evaluating alert #${alert.number}: ${ruleId}`);
-              
-              if (!scanHasAnyIssues) {
-                // No issues in current scan, close this alert
-                try {
-                  await github.rest.codeScanning.updateAlert({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    alert_number: alert.number,
-                    state: 'dismissed',
-                    dismissed_reason: 'false_positive',
-                    dismissed_comment: 'Issue appears to be fixed - not found in current scan'
-                  });
-                  console.log(`✅ Closed alert #${alert.number} (issue appears fixed)`);
-                  closedCount++;
-                } catch (error) {
-                  console.log(`❌ Failed to close alert #${alert.number}: ${error.message}`);
-                }
-              } else {
-                console.log(`✓ Keeping alert #${alert.number} open (issues still exist in scan)`);
-                keptOpenCount++;
-              }
-            }
-            
-            console.log(`\n📊 Alert cleanup summary:`);
-            console.log(`   Alerts closed (fixed): ${closedCount}`);
-            console.log(`   Alerts kept open (persistent): ${keptOpenCount}`);
-            
-          } catch (error) {
-            console.log('❌ Error in alert cleanup logic:', error.message);
-          }
 
     - name: Archive scan results
       if: always()


### PR DESCRIPTION
## Testing PR Workflow

This PR tests:
- ✅ Changing scan target from `learn-terraform-provision-eks-cluster` to `terraform-aws-eks`
- ✅ How Trivy security scan results appear in PR context
- ✅ Whether scan results show in PR checks/comments
- ✅ Security tab integration for PR-triggered scans

### Changes:
- Updated `scan-ref` to target `example_app/terraform-aws-eks` folder
- Added descriptive comment to workflow file

Let's see what security issues Trivy finds in the new target folder! 🔍