### PR TITLE
Test Security Scan with EKS Example App

### DIFF
--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -29,8 +29,8 @@ jobs:
 
     - name: Run secrets scan
       run: |
-        trufflehog filesystem example_app/django-ecs-terraform --json > secrets-results.json || echo "[]" > secrets-results.json
-        trufflehog filesystem example_app/django-ecs-terraform --format=sarif > secrets-results.sarif || echo '{"version":"2.1.0","$schema":"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json","runs":[{"tool":{"driver":{"name":"TruffleHog"}},"results":[]}]}' > secrets-results.sarif
+        trufflehog filesystem example_app/learn-terraform-provision-eks-cluster --json > secrets-results.json || echo "[]" > secrets-results.json
+        trufflehog filesystem example_app/learn-terraform-provision-eks-cluster --format=sarif > secrets-results.sarif || echo '{"version":"2.1.0","$schema":"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json","runs":[{"tool":{"driver":{"name":"TruffleHog"}},"results":[]}]}' > secrets-results.sarif
 
     - name: Upload secrets results to Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -44,7 +44,7 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
-        scan-ref: 'example_app/django-ecs-terraform'
+        scan-ref: 'example_app/learn-terraform-provision-eks-cluster'
         format: 'sarif'
         output: 'iac-results.sarif'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
@@ -53,7 +53,7 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'config'
-        scan-ref: 'example_app/django-ecs-terraform'
+        scan-ref: 'example_app/learn-terraform-provision-eks-cluster'
         format: 'table'
         output: 'iac-results.txt'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
@@ -70,7 +70,7 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'fs'
-        scan-ref: 'example_app/django-ecs-terraform'
+        scan-ref: 'example_app/learn-terraform-provision-eks-cluster'
         format: 'sarif'
         output: 'dependency-results.sarif'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
@@ -79,7 +79,7 @@ jobs:
       uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'fs'
-        scan-ref: 'example_app/django-ecs-terraform'
+        scan-ref: 'example_app/learn-terraform-provision-eks-cluster'
         format: 'table'
         output: 'dependency-results.txt'
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'


### PR DESCRIPTION
## Purpose
This PR changes the example app from `django-ecs-terraform` to `learn-terraform-provision-eks-cluster` to:

1. **Test different Infrastructure**: Scan EKS-related Terraform configurations instead of ECS
2. **Validate Security Tab Dismissal**: Check if previously dismissed issues from django-ecs-terraform stay dismissed while new EKS issues appear
3. **Compare Security Results**: See how different infrastructure types produce different security findings

## Changes Made
- Updated all `scan-ref` paths in the workflow from `example_app/django-ecs-terraform` to `example_app/learn-terraform-provision-eks-cluster`
- TruffleHog secrets scanning now targets EKS directory
- Trivy IaC scanning now analyzes EKS terraform files
- Trivy dependency scanning now checks EKS dependencies

## Expected Results
- New security findings specific to EKS configuration
- Different IaC misconfigurations related to Kubernetes/EKS
- Potentially different dependency vulnerabilities
- Previously dismissed django-ecs-terraform issues should remain dismissed in Security tab

This will help us understand how the security scanning behaves with different example applications and validate the dismissal functionality.