### PR TITLE
Test: Verify TruffleHog Security Tab Integration

### DIFF
--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -33,8 +33,9 @@ jobs:
 
     - name: Run secrets scan
       run: |
-        trufflehog filesystem ${{ env.SCAN_TARGET }} --json > secrets-results.json || echo "[]" > secrets-results.json
-        trufflehog filesystem ${{ env.SCAN_TARGET }} --format=sarif > secrets-results.sarif || echo '{"version":"2.1.0","$schema":"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json","runs":[{"tool":{"driver":{"name":"TruffleHog"}},"results":[]}]}' > secrets-results.sarif
+        # Run TruffleHog with proper format flags
+        trufflehog filesystem ${{ env.SCAN_TARGET }} --json --results=verified,unknown > secrets-results.json || echo "[]" > secrets-results.json
+        trufflehog filesystem ${{ env.SCAN_TARGET }} --format=sarif --results=verified,unknown > secrets-results.sarif || echo '{"version":"2.1.0","$schema":"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json","runs":[{"tool":{"driver":{"name":"TruffleHog","version":"3.0"}},"results":[]}]}' > secrets-results.sarif
 
     - name: Upload secrets results to Security tab
       uses: github/codeql-action/upload-sarif@v3
@@ -99,7 +100,7 @@ jobs:
     - name: Create PR comment
       if: github.event_name == 'pull_request'
       run: |
-        # Fix: Parse secrets count properly and remove any newlines/duplicates
+        # Parse secrets count properly and remove any newlines/duplicates
         SECRETS_COUNT=$(cat secrets-results.json | jq -r 'length // 0' | tr -d '\n' | head -1)
         
         # Extract IaC Report Summary table directly from Trivy output
@@ -126,20 +127,41 @@ jobs:
           fi
         fi
         
+        # Generate secrets summary with robust parsing
+        SECRETS_DETAILS=""
+        if [ "$SECRETS_COUNT" -gt 0 ]; then
+          SECRETS_DETAILS="⚠️ **CRITICAL: Secrets detected!**\n\nFound in:"
+          # Try multiple TruffleHog JSON field patterns for compatibility
+          if command -v jq >/dev/null 2>&1; then
+            # Approach 1: Try modern TruffleHog v3+ structure
+            PARSED_SECRETS=$(cat secrets-results.json | jq -r '.[] | 
+              if .SourceMetadata.Data.Filesystem then
+                "- \(.DetectorName // "Unknown"): \(.SourceMetadata.Data.Filesystem.file):\(.SourceMetadata.Data.Filesystem.line // "?")"
+              elif .SourceName then
+                "- \(.DetectorName // "Unknown"): \(.SourceName) (line unknown)"
+              else
+                "- \(.DetectorName // "Unknown detector"): location unknown"
+              end' 2>/dev/null)
+            
+            if [ -n "$PARSED_SECRETS" ] && [ "$PARSED_SECRETS" != "null" ]; then
+              SECRETS_DETAILS="$SECRETS_DETAILS\n$PARSED_SECRETS"
+            else
+              SECRETS_DETAILS="$SECRETS_DETAILS\n- Found $SECRETS_COUNT secrets (check Security tab for details)"
+            fi
+          else
+            SECRETS_DETAILS="$SECRETS_DETAILS\n- Found $SECRETS_COUNT secrets (check Security tab for details)"
+          fi
+        else
+          SECRETS_DETAILS="✅ No secrets detected"
+        fi
+        
         cat > pr_comment.md << EOF
         ## 🛡️ Security Scan Results
         
         ### 🔐 Secrets Detection
         **Secrets Found:** $SECRETS_COUNT
         
-        $(if [ "$SECRETS_COUNT" -gt 0 ]; then
-          echo "⚠️ **CRITICAL: Secrets detected!**"
-          echo ""
-          echo "Found in:"
-          cat secrets-results.json | jq -r '.[] | "- \(.SourceMetadata.Data.Filesystem.file):\(.SourceMetadata.Data.Filesystem.line)"'
-        else
-          echo "✅ No secrets detected"
-        fi)
+        $(echo -e "$SECRETS_DETAILS")
         
         ### 🔒 IaC Security Issues
         

--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -99,7 +99,8 @@ jobs:
     - name: Create PR comment
       if: github.event_name == 'pull_request'
       run: |
-        SECRETS_COUNT=$(cat secrets-results.json | jq -r 'length // 0')
+        # Fix: Parse secrets count properly and remove any newlines/duplicates
+        SECRETS_COUNT=$(cat secrets-results.json | jq -r 'length // 0' | tr -d '\n' | head -1)
         
         # Extract IaC Report Summary table directly from Trivy output
         IAC_REPORT_SUMMARY=""

--- a/.github/workflows/trivy-iac-scan.yml
+++ b/.github/workflows/trivy-iac-scan.yml
@@ -100,8 +100,8 @@ jobs:
     - name: Create PR comment
       if: github.event_name == 'pull_request'
       run: |
-        # Parse secrets count properly and remove any newlines/duplicates
-        SECRETS_COUNT=$(cat secrets-results.json | jq -r 'length // 0' | tr -d '\n' | head -1)
+        # Parse secrets count
+        SECRETS_COUNT=$(cat secrets-results.json | jq -r 'length // 0' 2>/dev/null || echo "0")
         
         # Extract IaC Report Summary table directly from Trivy output
         IAC_REPORT_SUMMARY=""
@@ -127,29 +127,20 @@ jobs:
           fi
         fi
         
-        # Generate secrets summary with robust parsing
+        # Generate secrets summary
         SECRETS_DETAILS=""
         if [ "$SECRETS_COUNT" -gt 0 ]; then
           SECRETS_DETAILS="⚠️ **CRITICAL: Secrets detected!**\n\nFound in:"
-          # Try multiple TruffleHog JSON field patterns for compatibility
+          # Show secret details from JSON
           if command -v jq >/dev/null 2>&1; then
-            # Approach 1: Try modern TruffleHog v3+ structure
-            PARSED_SECRETS=$(cat secrets-results.json | jq -r '.[] | 
-              if .SourceMetadata.Data.Filesystem then
-                "- \(.DetectorName // "Unknown"): \(.SourceMetadata.Data.Filesystem.file):\(.SourceMetadata.Data.Filesystem.line // "?")"
-              elif .SourceName then
-                "- \(.DetectorName // "Unknown"): \(.SourceName) (line unknown)"
-              else
-                "- \(.DetectorName // "Unknown detector"): location unknown"
-              end' 2>/dev/null)
-            
-            if [ -n "$PARSED_SECRETS" ] && [ "$PARSED_SECRETS" != "null" ]; then
+            PARSED_SECRETS=$(cat secrets-results.json | jq -r '.[] | "- \(.DetectorName // "Unknown"): \(.SourceMetadata.Data.Filesystem.file // .SourceName // "unknown location")"' 2>/dev/null)
+            if [ -n "$PARSED_SECRETS" ]; then
               SECRETS_DETAILS="$SECRETS_DETAILS\n$PARSED_SECRETS"
             else
-              SECRETS_DETAILS="$SECRETS_DETAILS\n- Found $SECRETS_COUNT secrets (check Security tab for details)"
+              SECRETS_DETAILS="$SECRETS_DETAILS\n- Found $SECRETS_COUNT secrets"
             fi
           else
-            SECRETS_DETAILS="$SECRETS_DETAILS\n- Found $SECRETS_COUNT secrets (check Security tab for details)"
+            SECRETS_DETAILS="$SECRETS_DETAILS\n- Found $SECRETS_COUNT secrets"
           fi
         else
           SECRETS_DETAILS="✅ No secrets detected"


### PR DESCRIPTION
🧪 **Testing TruffleHog Integration Fix**

This PR tests the fix for TruffleHog secrets detection appearing in both:
- ✅ PR Comments (was working)
- 🔒 GitHub Security Tab (was broken, now fixed)

## What's being tested:
- Secrets detection in `example_app/terraform-aws-lambda-example`
- SARIF upload to Security tab with proper formatting
- PR comment generation with file locations
- All scan types: Secrets, IaC, Dependencies

## Expected Results:
- Secrets should appear in PR comment ✅
- Secrets should appear in Security tab ✅ 
- IaC and dependency scans should work as before

Let's see if our fix works! 🚀